### PR TITLE
Proposed fix for cloudminify.js and proposed change to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,12 @@ request rewiriting performed by the Cloudmine servers.
 ``` javascript
 const express = require('express');
 const app = express();
-const cloudminify = require('deCloudminify').cloudminify;
-app.use(cloudminify());
+if(process.env.NODE_ENV == 'development'){
+  const cloudminify = require('deCloudminify').cloudminify;
+  api.use(cloudminify());
+}
+const deCloudminify = require('deCloudminify').deCloudminify;
+api.use(deCloudminify());
 app.get('/foo/bar', (req, res) => {
   res.send({foo: 'bar'});
 });

--- a/lib/cloudminify.js
+++ b/lib/cloudminify.js
@@ -110,10 +110,8 @@ function isRouteMatch(path) {
   const parts = path
     .split('/')
     .filter(part => part !== '');
-  if (parts.length == 5 && parts[0] == 'v1' && parts[1] == 'app') {
-    if (parts[3] == 'run' && parts[4] == 'handler') {
-      return true;
-    }
+  if (parts.length == 5 && parts[0] == 'v1' && parts[1] == 'app' && parts[3] == 'run') {
+    return true;
   }
   return false;
 }


### PR DESCRIPTION
The change to the README should be self-explanatory, but I made the change to cloudminify.js because it was failing when the final snippet slug was anything but 'handler'. I didn't think you meant for all snippets registered with Cloudmine to be called "handler", so I ommitted the check against that final part of the url.